### PR TITLE
WIP CurveRecipe

### DIFF
--- a/contracts/interfaces/ICurveAddressProvider.sol
+++ b/contracts/interfaces/ICurveAddressProvider.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: Unlicense
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+interface ICurveAddressProvider {
+    /**
+        @notice Fetch the address associated with `id`.
+        @param _id index of the address to fetch
+        @return address associated with `_id`
+    */
+    function get_address(uint256 _id) external view returns(address);
+
+}

--- a/contracts/interfaces/ICurveExchange.sol
+++ b/contracts/interfaces/ICurveExchange.sol
@@ -1,0 +1,40 @@
+//SPDX-License-Identifier: Unlicense
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+interface ICurveExchange {
+    /**
+        @notice Perform an token exchange using a specific pool.
+        @param _pool Address of the pool to use for the swap
+        @param _from: Address of coin being sent.
+        @param _to: Address of coin being received.
+        @param _amount: Quantity of `_from` being sent.
+        @param _expected: Minimum quantity of `_to` received in order for the transaction to succeed.
+        @param _receiver: Optional address to transfer the received tokens to. If not specified, defaults to the caller.
+        @return Returns the amount of `_to` received in the exchange 
+    */
+    function exchange(
+        address _pool,
+        address _from,
+        address _to,
+        uint256 _amount,
+        uint256 _expected,
+        address _receiver
+    ) external payable returns(uint256);
+
+
+    /**
+        @notice Find the pool offering the best rate for a given swap.
+        @param _from: Address of coin being sent.
+        @param _to: Address of coin being received.
+        @param _amount: Quantity of `_from` being sent.
+        @return Returns the address of the pool offering the best rate, and the expected amount received in the swap 
+    */
+    function get_best_rate(
+        address _from,
+        address _to,
+        uint256 _amount
+    ) external view returns(address, uint256);
+
+}

--- a/contracts/recipes/CurveRecipe.sol
+++ b/contracts/recipes/CurveRecipe.sol
@@ -1,0 +1,78 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IRecipe.sol";
+import "../interfaces/IPieRegistry.sol";
+import "../interfaces/IPie.sol";
+import "../interfaces/ICurveAddressProvider.sol";
+import "../interfaces/ICurveExchange.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+contract CurveRecipe is IRecipe {
+    using SafeERC20 for IERC20;
+
+    ICurveAddressProvider immutable curveAddressProvider;
+    IPieRegistry immutable pieRegistry;
+
+    constructor(
+        address _addressProvider,
+        address _pieRegistry
+    ) {
+        curveAddressProvider = ICurveAddressProvider(_addressProvider);
+        pieRegistry = IPieRegistry(_pieRegistry);
+    }
+
+    function bake(
+        address _inputToken,
+        address _outputToken,
+        uint256 _maxInput,
+        bytes memory _
+    ) external override returns(uint256 inputAmountUsed, uint256 outputAmount) {
+        IERC20 inputToken = IERC20(_inputToken);
+        IERC20 outputToken = IERC20(_outputToken);
+
+        inputToken.safeTransferFrom(msg.sender, address(this), _maxInput);
+        
+        _bake(_inputToken, _outputToken, _maxInput);
+
+        uint256 remainingInput = inputToken.balanceOf(address(this));
+        inputAmountUsed = _maxInput - remainingInput;
+        
+        if(remainingInput > 0) {
+            inputToken.safeTransfer(msg.sender, remainingInput);
+        }
+
+        outputAmount = outputToken.balanceOf(address(this));
+        outputToken.safeTransfer(msg.sender, outputAmount);
+    }
+
+    function _bake(
+        address _inputToken,
+        address _outputToken,
+        uint256 _maxInput
+    ) internal {
+        require(_inputToken != _outputToken, "Input token should be different from output token");
+        require(pieRegistry.inRegistry(_outputToken), "Output token is not a PIE");
+
+        IPie pie = IPie(_outputToken);
+        ICurveExchange _exchange = ICurveExchange(curveAddressProvider.get_address(2));
+
+        (address[] memory tokens, uint256[] memory amounts) = pie.calcTokensForAmount(_maxInput);
+
+        IERC20(_inputToken).approve(address(_exchange), 0);
+        IERC20(_inputToken).approve(address(_exchange), _maxInput);
+
+        for(uint i = 1; i < tokens.length; i++) {
+            (address pool, uint256 amount) = _exchange.get_best_rate(_inputToken, tokens[i], amounts[i]);
+            _exchange.exchange(pool, _inputToken, tokens[i], amounts[i], amount, address(this));
+        }
+
+        for(uint i = 0; i < tokens.length; i++) {
+            IERC20(tokens[i]).approve(address(pie), 0);
+            IERC20(tokens[i]).approve(address(pie), amounts[i]);
+        }
+
+        pie.joinPool(_maxInput);
+    }
+}

--- a/contracts/recipes/UniPieRecipe.sol
+++ b/contracts/recipes/UniPieRecipe.sol
@@ -248,7 +248,7 @@ contract UniPieRecipe is IRecipe {
         );
     }
 
-    function encodeData(uint256 _outputAmount) external pure returns(bytes memory){
+    function encodeData(uint256 _outputAmount) external pure returns(bytes memory) {
         return abi.encode((_outputAmount));
     }
 }

--- a/scripts/curveExchangeTest.ts
+++ b/scripts/curveExchangeTest.ts
@@ -1,0 +1,39 @@
+import { constants, utils } from "ethers";
+import { parseEther } from "ethers/lib/utils";
+import { ethers, network } from "hardhat";
+import { ICurveAddressProvider__factory } from "../typechain/factories/ICurveAddressProvider__factory";
+import { ICurveExchange__factory } from "../typechain/factories/ICurveExchange__factory";
+
+const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+const TUSD = "0x0000000000085d4780B73119b644AE5ecd22b376";
+const DAI = "0x6b175474e89094c44da98b954eedeac495271d0f";
+const sUSD = "0x57ab1ec28d129707052df4df418d58a2d46d5f51";
+
+const addressProviderAddress = "0x0000000022D53366457F9d5E68Ec105046FC4383";
+
+const from = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+const amount = ethers.BigNumber.from("100000000"); // 100 USDC
+
+const main = async () => {
+    await network.provider.request({
+        method: "hardhat_impersonateAccount",
+        params: [from]}
+    )
+    
+    const signer = ethers.provider.getSigner(from);
+    const addressProvider = ICurveAddressProvider__factory.connect(addressProviderAddress, signer);
+    const exchangeAddress = await addressProvider.get_address(ethers.BigNumber.from(2));
+    console.log(`Curve Swap contract address: ${exchangeAddress}`);
+
+    const exchange = ICurveExchange__factory.connect(exchangeAddress, signer);
+
+    // gasEstimation for get_best_rate
+    let gasEstimation = await exchange.estimateGas.get_best_rate(USDC, DAI, amount);
+    console.log(`Gas estimation for get_best_rate: ${gasEstimation.toString()}`);
+
+    // getting the result
+    let result = await exchange.get_best_rate(USDC, DAI, amount);
+    console.log(`Best pool is ${result[0]} receiving ${result[1].toString()} DAI`);
+}
+
+main();


### PR DESCRIPTION
Some considerations about this WIP:

- `_bake` was written supposing that `IPie.calcTokensForAmount()` returns `(_, uint256[] amounts)` where `amounts` contains the amount of `_inputToken` to spend for each underlying asset 
- Does `IPie.joinPool(uint256)` receive the amount of `_inputToken` from which the`pie` is baked/minted?

Now some considerations about the implementation and possible edits:

- Gas consumption will be huge on this (basically `ICurveExchange.get_best_rate` requires a lot of gas). We should think about exposing a pure function as: `getBestPools(address _inputToken, address[] _outputTokens)` that returns something like `address[] pools`, representing the best pools. This can be encoded (like in `UniPieRecipe`) and passed in the `data` field to `bake`.